### PR TITLE
Update wording for AMPlantfix changes

### DIFF
--- a/config/hqm/QuestFiles/Ars Magica.json
+++ b/config/hqm/QuestFiles/Ars Magica.json
@@ -154,7 +154,7 @@
     },
     {
       "name": "Magical Worldgen",
-      "description": "Ars Magica adds many flora and ores to the world. Many of these will be required in certain spells and related blocks. Thanks to Am2 Plant Fix, you can now obtain plants through bonemeal. You may use bonemeal on the following areas: brightly lit grass, water source blocks when dark and open to the sky, well lit sand, in the dark beneath ground on stone, grass under witchwood leaves. ",
+      "description": "Ars Magica adds many flora and ores to the world. Many of these will be required in certain spells and related blocks. Thanks to Am2 Plant Fix, you can now obtain plants through bonemeal. You may use bonemeal grass that is surrounded by the following areas: brightly lit grass, water source blocks open to the sky at night, well lit sand, Stone (not cobble) underground when dark, grass under witchwood leaves. ",
       "x": 24,
       "y": 57,
       "icon": {


### PR DESCRIPTION
Wording was not clear that bonemeal is used on Grass that is surrounded by the required materials, not on the stone/sand/water itself.